### PR TITLE
sub chart value tracking fix

### DIFF
--- a/pkg/test/coverage/tracker.go
+++ b/pkg/test/coverage/tracker.go
@@ -40,6 +40,29 @@ func NewTracker(usage *tpl.TemplateUsage, includeSubcharts bool) *Tracker {
 		if !includeSubcharts && strings.HasPrefix(templatePath, "charts/") {
 			continue
 		}
+
+		if strings.HasPrefix(templatePath, "charts/") {
+			for fieldIndex, field := range result.Fields {
+
+				if strings.HasPrefix(field, ".Values.global") || strings.HasPrefix(field, ".Release") {
+					continue
+				} else {
+
+					chartName := ""
+
+					temp := strings.Split(templatePath, "/")
+					if len(temp) > 1 {
+						chartName = temp[1]
+					}
+
+					if chartName != "" {
+						fieldWithValuesPrefixRemoved := strings.TrimPrefix(result.Fields[fieldIndex], ".Values")
+						result.Fields[fieldIndex] = ".Values." + chartName + fieldWithValuesPrefixRemoved
+					}
+				}
+			}
+		}
+
 		trackFieldsFromResult(result, templatePath, nil)
 	}
 	return &Tracker{


### PR DESCRIPTION
1. while checking coverage for sub charts hull read the values of subcharts same as they are defined in the files. 
for exa to override the subchart values we need to set the values while adding template options as 
```
SetValue("tracing.jaeger.repository", "jaeger-all-in-one"). // here tracing is subchart name
```
but for making hull to consider it for coverage following set value statement was needed
```
SetValue("jaeger.repository", "jaeger-all-in-one").
```
so a change is added so that hull read subchart values as ```.Values.subChartName.ActualValueKey```