### PR TITLE
handle Hull API output which relies on non-OS specific `path` package

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -81,7 +81,7 @@ func (c *chart) RenderTemplate(opts *TemplateOptions) (Template, error) {
 		"": objectset.NewObjectSet(),
 	}
 	for source, manifestString := range templateYamls {
-		source := strings.SplitN(source, string(filepath.Separator), 2)[1]
+		source := strings.SplitN(source, "/", 2)[1]
 
 		// skip parsing non YAML source files.
 		if filepath.Ext(source) != ".yml" && filepath.Ext(source) != ".yaml" {


### PR DESCRIPTION
While running charts test on windows, I noticed that hull would error out with the following log: 

```
panic: runtime error: index out of range [1] with length 1 [recovered]
	panic: runtime error: index out of range [1] with length 1

goroutine 7 [running]:
testing.tRunner.func1.2({0x244fca0, 0xc0002f9ec0})
	C:/Program Files/Go/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
	C:/Program Files/Go/src/testing/testing.go:1548 +0x397
panic({0x244fca0?, 0xc0002f9ec0?})
	C:/Program Files/Go/src/runtime/panic.go:914 +0x21f
github.com/rancher/hull/pkg/chart.(*chart).RenderTemplate(0xc0002b37d0, 0xc000410fc0?)
	C:/Users/adminuser/go/pkg/mod/github.com/rancher/hull@v0.0.0-20230424152137-627ef5347afd/pkg/chart/chart.go:84 +0x7ff
github.com/rancher/hull/pkg/test.(*Suite).Run.func1(0xc0001d1a00)
	C:/Users/adminuser/go/pkg/mod/github.com/rancher/hull@v0.0.0-20230424152137-627ef5347afd/pkg/test/suite.go:124 +0x78
testing.tRunner(0xc0001d1a00, 0xc00049cdc0)
	C:/Program Files/Go/src/testing/testing.go:1595 +0xff
```

After investigating, this issue seems to stem from how the Helm API returns charts after calling `c.Render` within [Hulls `RenderTemplate` function.](https://github.com/rancher/hull/blob/627ef5347afd648875d70f5237b542fe47a5b733/pkg/chart/chart.go#L63)

[As the Helm API recurses through the chart files, it builds out the file paths using the `path` library.](https://github.com/helm/helm/blob/1338ffe6083990ceefb74b9ab5559689de8d791d/pkg/engine/engine.go#L360-L408) Unfortunately, the `path` library does not take into account OS specific file separators, only `path/filepath` does. 

Hull will use this output to further render only the yaml files so that they may be tested. However, Hull is [(properly) using the `filepath.Seperator` constant](https://github.com/rancher/hull/blob/627ef5347afd648875d70f5237b542fe47a5b733/pkg/chart/chart.go#L83-L85) to split template names from their paths to identify the yaml files. By splitting the value using the `filepath.Seperator` constant, as well as the immediate indexing into the resulting slice, we run into the above error.

The fix proposed in this PR is to no longer use the `filepath.Seperator` constant, as Helm will always return linux path separators. This results in Hull tests working as expected on Windows, and does not impact linux/macos. Changing this in Helm itself would likely be a major breaking change, as this logic has existed for ~7 years.